### PR TITLE
train on only one hodge number

### DIFF
--- a/prep_work.py
+++ b/prep_work.py
@@ -24,6 +24,7 @@ def data_wrangle_S():
             for idx, line in enumerate(file.readlines()[1:]):
                 if idx%6 == 0: Sweights.append(eval(line))
                 if idx%6 == 2: SHodge.append(eval(line))
+    Sweights, SHodge = np.array(Sweights), np.array(SHodge)[:, 1]
     return Sweights, SHodge
 
 ################################################################################
@@ -35,13 +36,12 @@ def get_network():
     h1 = tf.keras.layers.Dense(16, activation='relu')(prep)
     h2 = tf.keras.layers.Dense(32, activation='relu')(h1)
     h3 = tf.keras.layers.Dense(16, activation='relu')(h2)
-    out = tf.keras.layers.Dense(2, activation='linear')(h3)
+    out = tf.keras.layers.Dense(1, activation='linear')(h3)
 
     model = tf.keras.models.Model(inputs=inp, outputs=out)
     model.compile(
         loss='mean_squared_error',
-        optimizer=tf.keras.optimizers.Adam(0.001),
-        metrics = ['accuracy']
+        optimizer=tf.keras.optimizers.Adam(0.001)
     )
     return model
 
@@ -60,8 +60,8 @@ def train_network(X_train, y_train, X_test, y_test):
 #defining accuracy as in the paper
 
 def daattavya_accuracy(weights, hodge_numbers, model):
+    #input hodge numbers as numpy array shape (N,), where N is the number of hodge numbers
     bound = 0.05*(np.max(hodge_numbers)-np.min(hodge_numbers)) #define the bound as done in Daattavya's paper
-    weights, hodge_numbers = np.array(weights), np.array(hodge_numbers) #turn into numpy arrays for ease
     random_indices = np.random.choice(np.array(weights).shape[0], 1000, replace=False) #make a selection as to not work with all the data
     random_selection = weights[random_indices] 
     predictions = model.predict(random_selection)


### PR DESCRIPTION
we originally trained on both sasakian hodge numbers, but only one of them is actually changing, so our accuracy was artificially inflated etc. but now it seems weirdly low when we train it only on one (getting like 40%)